### PR TITLE
Improve workflow robustness

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,23 +27,21 @@ jobs:
         shell: pwsh
         run: |
           dir
-          dir .\Source
-          dir .\Source\FixAllTool
-          dir .\ai_service
+          dir .\Source -ea 0
+          dir .\Source\FixAllTool -ea 0
+          dir .\ai_service -ea 0
 
       - name: Install Python deps
         shell: pwsh
         run: |
           python -m pip install --upgrade pip
-          pip install -r ai_service\requirements.txt
+          if (Test-Path ai_service\requirements.txt) { pip install -r ai_service\requirements.txt }
           pip install pyinstaller
 
       - name: Build ai_service.exe
         shell: pwsh
         run: |
-          pyinstaller --onefile --name ai_service ai_service\app.py
-          New-Item -ItemType Directory -Path dist -Force | Out-Null
-          Copy-Item .\dist\ai_service.exe .\dist -Force
+          if (Test-Path ai_service\app.py) { pyinstaller --onefile --name ai_service ai_service\app.py --distpath dist }
 
       - name: Publish WPF single-file EXE
         shell: pwsh


### PR DESCRIPTION
## Summary
- guard `pip install -r` with existence check for ai_service requirements
- streamline `pyinstaller` output by writing directly to `dist`
- tolerate missing directories in debug listing and skip pyinstaller when `ai_service` source is absent

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-release.yml")'`
- `apt-get update` *(fails: repository '... InRelease' is not signed, 403 Forbidden)*
- `apt-get install -y yamllint && yamllint .github/workflows/build-release.yml` *(fails: Unable to locate package yamllint)*

------
https://chatgpt.com/codex/tasks/task_e_6897922aeb548323a057d879cbd2975d